### PR TITLE
Add API docs workflow

### DIFF
--- a/.github/workflows/render-documentation.yml
+++ b/.github/workflows/render-documentation.yml
@@ -1,0 +1,29 @@
+name: Render Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/render-documentation.ya?ml"
+      - "./libraries/WiFiS3/examples/**"
+      - "./libraries/WiFiS3/src/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/render-documentation.ya?ml"
+      - "./libraries/WiFiS3/examples/**"
+      - "./libraries/WiFiS3/src/**"
+  workflow_dispatch:
+      
+jobs:
+  render-docs:
+    permissions:
+      contents: write
+    uses: arduino/render-docs-github-action/.github/workflows/render-docs.yml@main
+    with:
+      source-path: './libraries/WiFiS3/src'
+      target-path: './libraries/WiFiS3/docs/api.md'
+      exclude-pattern: 'StringHelpers.h WiFi.h Modem.h'
+      commit: ${{ github.event_name != 'pull_request' }} # Only commit changes if not a PR


### PR DESCRIPTION
This PR adds a workflow to the Renesas core that automatically renders the API documentation of the specified libraries.